### PR TITLE
include counters parameter in server_info command

### DIFF
--- a/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
+++ b/content/references/http-websocket-apis/public-api-methods/server-info-methods/server_info.md
@@ -21,6 +21,11 @@ An example of the request format:
 {
   "id": 1,
   "command": "server_info"
+},
+{
+  "id": 1,
+  "command": "server_info",
+  "counters": true
 }
 ```
 
@@ -32,6 +37,12 @@ An example of the request format:
     "params": [
         {}
     ]
+},
+{
+    "method": "server_info",
+    "params": [
+        {"counters" : true}
+    ]
 }
 ```
 
@@ -40,13 +51,14 @@ An example of the request format:
 ```sh
 #Syntax: server_info
 rippled server_info
+rippled server_info counters # for optional performance statistics
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
 [Try it! >](websocket-api-tool.html#server_info)
 
-The request does not take any parameters.
+The request takes in an optional `counters` parameter. It will render metrics pertaining to Job Queue, nodestore and RPC call counters.
 
 ## Response Format
 
@@ -129,6 +141,9 @@ The `info` object may have some arrangement of the following fields:
 | `validated_ledger.seq`              | Number          | The [ledger index][] of the latest validated ledger. |
 | `validation_quorum`                 | Number          | Minimum number of trusted validations required to validate a ledger version. Some circumstances may cause the server to require more validations. |
 | `validator_list_expires`            | String          | _(Admin only)_ Either the human readable time, in UTC, when the current validator list expires, the string `unknown` if the server has yet to load a published validator list or the string `never` if the server uses a static validator list. |
+| `counters`            | Object          | This object contains performance metrics pertaining to the RPC Calls (currently executing calls and the completed calls) and the JobQueue. It also contains the details of the nodestore like node_writes, node_reads_total, node_reads_hit, etc|
+| `current_activity`            | Object          | This field contains two arrays for `jobs` and `methods`. |
+
 
 **Note:** If the `closed_ledger` field is present and has a small `seq` value (less than 8 digits), that indicates `rippled` does not currently have a copy of the validated ledger from the peer-to-peer network. This could mean your server is still syncing. Typically, it takes about 5 minutes to sync with the network, depending on your connection speed and hardware specs.
 


### PR DESCRIPTION
Fix #4752 (https://github.com/XRPLF/rippled/issues/4752)
This PR attempts to document the usage of the `counters` parameter in the `rippled server_info` command.

